### PR TITLE
Implement Base Map Component

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,14 +9,17 @@
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.1",
+        "leaflet": "^1.9.4",
         "partysocket": "1.1.16",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
+        "react-leaflet": "^5.0.0",
         "react-router": "^7.13.1",
         "tailwindcss": "^4.2.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
+        "@types/leaflet": "^1.9.21",
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
@@ -1110,6 +1113,17 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@react-leaflet/core": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-3.0.0.tgz",
+      "integrity": "sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ==",
+      "license": "Hippocratic-2.1",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -1750,12 +1764,29 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "license": "MIT"
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.21",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.21.tgz",
+      "integrity": "sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "24.11.0",
@@ -3222,6 +3253,12 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -4388,6 +4425,20 @@
       },
       "peerDependencies": {
         "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-leaflet": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-5.0.0.tgz",
+      "integrity": "sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==",
+      "license": "Hippocratic-2.1",
+      "dependencies": {
+        "@react-leaflet/core": "^3.0.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
       }
     },
     "node_modules/react-refresh": {

--- a/client/package.json
+++ b/client/package.json
@@ -11,14 +11,17 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.1",
+    "leaflet": "^1.9.4",
+    "partysocket": "1.1.16",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "react-leaflet": "^5.0.0",
     "react-router": "^7.13.1",
-    "tailwindcss": "^4.2.1",
-    "partysocket": "1.1.16"
+    "tailwindcss": "^4.2.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
+    "@types/leaflet": "^1.9.21",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
@@ -28,9 +31,9 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
+    "partykit": "0.0.115",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.48.0",
-    "vite": "^7.3.1",
-    "partykit": "0.0.115"
+    "vite": "^7.3.1"
   }
 }

--- a/client/src/components/Map.tsx
+++ b/client/src/components/Map.tsx
@@ -1,0 +1,36 @@
+import { MapContainer, TileLayer, useMapEvents } from "react-leaflet";
+import "leaflet/dist/leaflet.css"
+
+interface MapViewProps {
+    onGuess: (lat: number, lng: number) => void;
+    disabled: boolean;
+}
+
+// Pass in some function to handle a click when the user presses on the map
+function ClickHandler({ onGuess, disabled }: MapViewProps) {
+    useMapEvents({
+        click(e) {
+            if (!disabled) {
+                onGuess(e.latlng.lat, e.latlng.lng);
+            }
+        },
+    });
+    return null;
+}
+
+export function MapView({ onGuess, disabled }: MapViewProps) {
+    return (
+        <MapContainer
+            center={[20, 0]}
+            zoom={2}
+            className="w-full h-96 rounded-xl"
+            style={{ cursor: disabled ? "not-allowed" : "crosshair" }}
+        >
+            <TileLayer
+                attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+                url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+            />
+            <ClickHandler onGuess={onGuess} disabled={disabled} />
+        </MapContainer>
+    );
+}

--- a/client/src/pages/Play.tsx
+++ b/client/src/pages/Play.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate, Navigate } from "react-router";
 import { usePartySocket } from "../hooks/usePartySocket";
 import { Lobby } from "../components/Lobby";
 import { Scoreboard } from "../components/Scoreboard";
+import { MapView } from "../components/Map";
 
 export function Play() {
     const { roomCode } = useParams<{ roomCode?: string }>();
@@ -132,10 +133,21 @@ export function Play() {
                         <p className="text-black mb-4">
                             Listen to the audio clip and click on the map to guess the origin.
                         </p>
-                        {/* Placeholder for map + audio */}
-                        <div className="bg-gray-300 rounded-xl h-96 flex items-center justify-center text-black/50 text-lg">
-                            Map / Audio area (TBD)
-                        </div>
+                        {/* Map (with audio feature WIP) */}
+                        <MapView
+                            onGuess={(lat, lng) =>
+                                sendMessage({
+                                    type: "guess",
+                                    lat,
+                                    lng,
+                                    round: gameState.currentRound,
+                                })
+                            }
+                            disabled={
+                                gameState.players.find((p) => p.id === currentPlayerId)
+                                    ?.hasGuessed ?? false
+                            }
+                        />
 
                         {/* Temporary: manual guess button for testing */}
                         <button


### PR DESCRIPTION
# What
- Create a basic map view component leveraging the Leaflet API
- Clicks on the map amount to a guess
- The map gets disabled for a user after they make a guess, and the turn is still going

# Look
<img width="2032" height="1071" alt="Screenshot 2026-03-13 at 6 07 39 PM" src="https://github.com/user-attachments/assets/1bee35bd-1b46-4388-8f3d-4939055e6079" />

# How to Test
- Run `npm run dev` in `client`, and in a separate terminal window, run `npx partykit dev`
- Create a lobby and start a game in two browser windows
- Verify that the map is visible
- Simulate a game by taking turns pressing random spots on the map
